### PR TITLE
fix json gem patch version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: .
   specs:
-    facebookbusiness (0.15.0.2)
+    facebookbusiness (19.0.0)
       concurrent-ruby (~> 1.1)
       countries (>= 3, < 6)
-      faraday (~> 2.6)
-      faraday-multipart (~> 1.0)
+      faraday (~> 2.6.0)
+      faraday-multipart (~> 1.0.4)
       json (~> 2.6)
       money (~> 6.13)
 
@@ -16,30 +16,27 @@ GEM
     awesome_print (1.9.2)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.2.0)
+    concurrent-ruby (1.2.3)
     coolline (0.5.0)
       unicode_utils (~> 1.4)
-    countries (3.1.0)
-      i18n_data (~> 0.11.0)
-      sixarm_ruby_unaccent (~> 1.1)
-      unicode_utils (~> 1.4)
+    countries (5.7.2)
+      unaccent (~> 0.3)
     diff-lcs (1.5.0)
     dotenv (2.8.1)
-    faraday (2.7.4)
+    faraday (2.6.0)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    i18n_data (0.11.0)
-    json (2.6.3)
+    json (2.7.1)
     method_source (1.0.0)
     minitest (5.14.4)
     money (6.16.0)
       i18n (>= 0.6.4, <= 2)
-    multipart-post (2.3.0)
+    multipart-post (2.4.0)
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
@@ -79,12 +76,13 @@ GEM
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    sixarm_ruby_unaccent (1.2.0)
+    unaccent (0.4.0)
     unicode-display_width (1.8.0)
     unicode_utils (1.4.0)
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
 
 DEPENDENCIES
   awesome_print (~> 1.8)

--- a/facebookbusiness.gemspec
+++ b/facebookbusiness.gemspec
@@ -35,10 +35,10 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
 
   s.add_dependency 'concurrent-ruby', '~> 1.1'
-  s.add_dependency 'faraday', '~> 2.6'
+  s.add_dependency 'faraday', '~> 2.6.0'
   s.add_dependency 'faraday-multipart', '~> 1.0.4'
   s.add_dependency 'json', '~> 2.6'
-  s.add_dependency 'countries', '>= 3', '< 6'  
+  s.add_dependency 'countries', '>= 3', '< 6'
   s.add_dependency 'money', '~> 6.13'
 
   s.add_development_dependency 'awesome_print', '~> 1.8'


### PR DESCRIPTION
fix Json gem to 2.6.0 as 2.7.0 does not seem to support the `object_class` option (tested with Ruby 3.1.2)